### PR TITLE
Ability to run command in a terminal when it is not the active tab

### DIFF
--- a/keymaps/terminal.cson
+++ b/keymaps/terminal.cson
@@ -1,5 +1,7 @@
 'body':
   'ctrl-`': 'terminal:open'
+  'ctrl-r': 'terminal:run-command'
+  'ctrl-shift-r': 'terminal:run-last-command'
 
 '.terminal':
   'enter': 'terminal:enter'

--- a/lib/terminal-command-prompt-view.coffee
+++ b/lib/terminal-command-prompt-view.coffee
@@ -1,0 +1,34 @@
+{View, EditorView} = require 'atom'
+
+module.exports =
+class TerminalCommandPromptView extends View
+  @content: ->
+    @div class: 'terminal-prompt overlay from-top', =>
+      @div class: 'editor-container', outlet: 'editorContainer', =>
+        editor = new EditorView(mini: true)
+        editor.setPlaceholderText "enter command"
+        @subview 'editor', editor
+
+  initialize: (@terminal) ->
+
+  handleEvents: ->
+    @editor.on 'core:confirm', @confirm
+    @editor.on 'core:cancel', @remove
+    @editor.find('input').on 'blur', @remove
+
+  focus: =>
+    @removeClass('hidden')
+    @editorContainer.find('.editor').focus()
+
+  confirm: =>
+    @terminal.runCommand @editor.getText()
+    @remove()
+
+  remove: =>
+    atom.workspaceView?.focus()
+    @addClass('hidden')
+
+  toggle: ->
+    atom.workspaceView.append(@)
+    @focus()
+    @handleEvents()

--- a/lib/terminal.coffee
+++ b/lib/terminal.coffee
@@ -17,6 +17,7 @@ Terminal =
       atom.workspaceView.open("terminal://#{initialDirectory}")
 
     atom.workspaceView.command 'terminal:run-command', => @toggleCommandPrompt()
+    atom.workspaceView.command 'terminal:run-last-command', => @runLastCommand()
 
   deactivate: ->
     atom.project.unregisterOpener(@customOpener)
@@ -49,6 +50,7 @@ Terminal =
 
   runCommand: (command) ->
     return unless command
+    @lastCommand = command
     session = @activeSessions[0]
     return unless session
 
@@ -62,3 +64,9 @@ Terminal =
         @runCommand(command)
       else
         throw(error)
+
+  runLastCommand: ->
+    if @lastCommand
+      @runCommand @lastCommand
+    else
+      @toggleCommandPrompt()

--- a/lib/terminal.coffee
+++ b/lib/terminal.coffee
@@ -1,19 +1,22 @@
 TerminalSession = null
-createTerminalSession = (state) ->
-  TerminalSession ?= require './terminal-session'
-  new TerminalSession(state)
+TerminalBuffer = null
+TerminalCommandPromptView = null
 
 atom.deserializers.add
   name: 'TerminalSession'
   version: 1
-  deserialize: (state) -> createTerminalSession(state)
+  deserialize: (state) -> Terminal.createTerminalSession(state)
 
 module.exports =
+Terminal =
   activate: ->
-    atom.project.registerOpener(@customOpener)
+    atom.project.registerOpener (uri) => @customOpener(uri)
+
     atom.workspaceView.command 'terminal:open', ->
       initialDirectory = atom.project.getPath() ? '~'
       atom.workspaceView.open("terminal://#{initialDirectory}")
+
+    atom.workspaceView.command 'terminal:run-command', => @toggleCommandPrompt()
 
   deactivate: ->
     atom.project.unregisterOpener(@customOpener)
@@ -21,4 +24,41 @@ module.exports =
   customOpener: (uri) ->
     if match = uri?.match(/^terminal:\/\/(.*)/)
       initialDirectory = match[1]
-      createTerminalSession({path: initialDirectory})
+      @createTerminalSession({path: initialDirectory})
+
+  activeSessions: []
+
+  createTerminalSession: (state) ->
+    TerminalSession ?= require './terminal-session'
+    session = new TerminalSession(state)
+    @registerSession(session)
+    session
+
+  registerSession: (session) ->
+    @activeSessions.push(session)
+    session.on 'exit', => @removeSession(session)
+
+  removeSession: (session) ->
+    index = @activeSessions.indexOf(session)
+    @activeSessions.splice(index, 1) if index != -1
+
+  toggleCommandPrompt: ->
+    TerminalCommandPromptView ?= require('./terminal-command-prompt-view')
+    @commandPromptView ?= new TerminalCommandPromptView(this)
+    @commandPromptView.toggle()
+
+  runCommand: (command) ->
+    return unless command
+    session = @activeSessions[0]
+    return unless session
+
+    TerminalBuffer ?= require './terminal-buffer'
+
+    try
+      session.emit 'input', command + TerminalBuffer.enter
+    catch error
+      if /terminated process/.test(error.message)
+        @removeSession(session)
+        @runCommand(command)
+      else
+        throw(error)


### PR DESCRIPTION
It is many times useful to be able to run a command remotely. Think unit tests or build tasks. This is a first shot at providing that feature.

The new `terminal:run-command` (mapped to `ctrl-r`) command opens a command prompt at the top of the window and sends the provided command as input to the terminal session that was activated first. It tracks active sessions, and removes sessions when they are exited or their tab closed.

There's also a `terminal:run-last-command` (mapped to `ctrl-shift-r`) command which runs the last command again.

I also included a little bit of refactoring in `terminal.coffee` making the `createTerminalSession` function a method on `Terminal`. It made sense for easier tracking of active sessions. I know it's best to keep refactoring as separate commits, but I was already too deep into it to go back. However, if you don't agree with the way I did it, let's discuss and in any case I can add it back the way it was.

I'm also thinking about how to allow the user to select which session the command runs in. One way would be to add a shortcut under the `.terminal` scope for selecting the currently active terminal tab as a target for commands. Another would be to open a new terminal tab on the first command and keep using that for subsequent commands.

As I said, this is a first shot. I would love to get some input, thoughts for improvements, etc. I will add specs for the new features later.
