### PR TITLE
cmd-shift-p

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ our progress for those who are interested. Proceed at your own risk!
 Adds support for opening terminals inside of Atom.
 
 You can open a new terminal with **ctrl-`** or from the command palette
-via **cmd-p**, typing 'terminal', and selecting the 'Terminal: Open' command.
+via **cmd-shift-p**, typing 'terminal', and selecting the 'Terminal: Open' command.
 
 ![Screenshot](https://f.cloud.github.com/assets/1789/2288483/604662ae-9ffa-11e3-933e-813279d5a40e.png)


### PR DESCRIPTION
To open the command palette isn't it cmd-shift-p not cmd-p?
