### PR TITLE
Fixes reporting of terminal dimensions.

### DIFF
--- a/lib/terminal-view.coffee
+++ b/lib/terminal-view.coffee
@@ -113,7 +113,7 @@ class TerminalView extends ScrollView
     @trigger 'view-updated'
 
   updateTerminalSize: () ->
-    tester = $("<pre><span class='character'>a</span></pre>")
+    tester = $("<pre class='line'><span class='character'>a</span></pre>")
     @renderedLines.append(tester)
     charWidth = parseInt(tester.find("span").css("width"))
     lineHeight = parseInt(tester.css("height"))


### PR DESCRIPTION
The tester line inserted by updateTerminalSize didn't include
class='line' on the pre element which caused it to get a bad line height
and to underreport the size of the terminal.
