### PR TITLE
Make `env` configurable via config

### DIFF
--- a/lib/terminal-process.coffee
+++ b/lib/terminal-process.coffee
@@ -1,6 +1,6 @@
 pty = require 'pty.js'
 
-module.exports = (ptyCwd) ->
+module.exports = (ptyCwd, ptyEnv) ->
   callback = @async()
   if process.platform is 'win32'
     shell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
@@ -18,7 +18,7 @@ module.exports = (ptyCwd) ->
     cols: cols
     rows: rows
     cwd: ptyCwd
-    env: process.env
+    env: ptyEnv
 
   ptyProcess.on 'data', (data) -> emit('terminal:data', data)
   ptyProcess.on 'exit', ->

--- a/lib/terminal-session.coffee
+++ b/lib/terminal-session.coffee
@@ -31,7 +31,9 @@ class TerminalSession
 
   forkPtyProcess: ->
     processPath = require.resolve('./terminal-process')
-    Task.once(processPath, fs.absolute(@path))
+    env = atom.config.get('terminal.env') ? {}
+    env[key] = val for key, val of process.env
+    Task.once(processPath, fs.absolute(@path), env)
 
   serialize: ->
     deserializer: 'TerminalSession'


### PR DESCRIPTION
Additional environment variables can now be specified in `config.cson`, under `terminal.env`.
