### PR TITLE
Changed focus behavior to allow copy/paste

### DIFF
--- a/keymaps/terminal.cson
+++ b/keymaps/terminal.cson
@@ -16,6 +16,7 @@
 
 '.platform-darwin .terminal':
   'cmd-v': 'terminal:paste'
+  'cmd-c': 'terminal:copy'
   'cmd-alt-r': 'terminal:reload'
 
 '.platform-win32 .terminal':


### PR DESCRIPTION
Avoid changing focus on click as well as on cmd,cmd-c,ctrl,ctrl-c keystrokes to preserve selection. 
