### PR TITLE
Detect full width chars

### DIFF
--- a/lib/terminal-view.coffee
+++ b/lib/terminal-view.coffee
@@ -80,6 +80,8 @@ class TerminalView extends ScrollView
       [color, bgcolor] = [bgcolor, color]
     @characterColor(char, color, bgcolor)
     (char.addClass(s) if c[s] == true) for s in ['bold', 'italic', 'underlined']
+    if text.match /^[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]$/
+      char.addClass("wide")
     char
 
   renderLine: (lineNumber, chars) ->

--- a/stylesheets/terminal.less
+++ b/stylesheets/terminal.less
@@ -23,6 +23,10 @@
       text-align: center;
       float: left;
       position: relative;
+
+      &.wide {
+        width: 1.2em;
+      }
     }
   }
 


### PR DESCRIPTION
This pull request detects if full width characters exist and apply them with `wide` class, enabling them to be styled with correct width (`1.2em` instead of `0.6em` in the current builtin stylesheet.)
